### PR TITLE
feat: 2026 anniversary updates

### DIFF
--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -31,6 +31,9 @@ const (
 	Anniv2025Stats           = "anniv_stats_2025"
 	Anniv2025RecordHistory   = "anniv_record_history_2025"
 	Anniv2025RecordsTable    = "anniv_records_2025"
+	Anniv2026Stats           = "anniv_stats_2026"
+	Anniv2026RecordHistory   = "anniv_record_history_2026"
+	Anniv2026RecordsTable    = "anniv_records_2026"
 	RecentGamesByPlayerTable = "recent_games_by_player_2"
 	RecentGamesByMonth       = "recent_games_by_month_2"
 	GameCountTable           = "games_counter"
@@ -374,9 +377,9 @@ func WriteGameByQuestRecord(questRun *model.QuestRun, dynamoClient *dynamodb.Dyn
 	return err
 }
 
-func WriteAnniv2025Record(questRun *model.QuestRun, dynamoClient *dynamodb.DynamoDB) error {
-	summary, err := writeRecord(Anniv2025RecordsTable, questRun, dynamoClient)
-	writeRecordHistory(Anniv2025RecordHistory, summary, dynamoClient)
+func WriteAnniv2026Record(questRun *model.QuestRun, dynamoClient *dynamodb.DynamoDB) error {
+	summary, err := writeRecord(Anniv2026RecordsTable, questRun, dynamoClient)
+	writeRecordHistory(Anniv2026RecordHistory, summary, dynamoClient)
 	return err
 }
 
@@ -423,6 +426,10 @@ func GetAnniv2023Record(quest string, numPlayers int, pbCategory bool, dynamoCli
 
 func GetAnniv2025Record(quest string, numPlayers int, pbCategory bool, dynamoClient *dynamodb.DynamoDB) (*model.Game, error) {
 	return getRecord(Anniv2025RecordsTable, quest, numPlayers, pbCategory, dynamoClient)
+}
+
+func GetAnniv2026Record(quest string, numPlayers int, pbCategory bool, dynamoClient *dynamodb.DynamoDB) (*model.Game, error) {
+	return getRecord(Anniv2026RecordsTable, quest, numPlayers, pbCategory, dynamoClient)
 }
 
 func GetQuestRecords(tableName string, dynamoClient *dynamodb.DynamoDB) ([]model.Game, error) {
@@ -649,7 +656,7 @@ func addAnniversaryCounter(questName, counterName string, value int64, db *dynam
 	questNameAttr := dynamodb.AttributeValue{S: aws.String(questName)}
 
 	updateItemInput := dynamodb.UpdateItemInput{
-		TableName:        aws.String(Anniv2025Stats),
+		TableName:        aws.String(Anniv2026Stats),
 		Key:              map[string]*dynamodb.AttributeValue{"Key": &questNameAttr, "Counter": &counterAttr},
 		AttributeUpdates: map[string]*dynamodb.AttributeValueUpdate{"count": &update},
 	}

--- a/server/internal/server/display_aniv2022.go
+++ b/server/internal/server/display_aniv2022.go
@@ -126,7 +126,7 @@ func (s *Server) sortRecordHistory(games []model.Game) map[string][]RecordHistor
 		gamesByQuest[game.Quest] = gamesForQuest
 	}
 	for quest, gamesForQuest := range gamesByQuest {
-		nextGame := RecordHistoryPoint{Time: time.Date(2025, time.September, 12, 0, 0, 0, 0, time.UTC)}
+		nextGame := RecordHistoryPoint{Time: time.Date(2026, time.September, 12, 0, 0, 0, 0, time.UTC)}
 		if len(gamesForQuest) > 0 {
 			lastGame := gamesForQuest[len(gamesForQuest)-1]
 			nextGame.P1 = lastGame.P1
@@ -166,6 +166,8 @@ func (s *Server) getCounters(year int) (QuestCounters, map[string]QuestCounters)
 		tableName = db.Anniv2023Stats
 	} else if year == 2025 {
 		tableName = db.Anniv2025Stats
+	} else if year == 2026 {
+		tableName = db.Anniv2026Stats
 	}
 
 	if counters, err := db.GetAnniversaryCounters(tableName, s.dynamoClient); err == nil {

--- a/server/internal/server/display_aniv2023.go
+++ b/server/internal/server/display_aniv2023.go
@@ -134,3 +134,67 @@ func (s *Server) Anniv2025RecordsPage(c *fiber.Ctx) error {
 	c.Response().Header.Set("Content-Type", "text/html; charset=UTF-8")
 	return err
 }
+
+func (s *Server) Anniv2026RecordsPage(c *fiber.Ctx) error {
+	const year = 2026
+	overallCounters, questCounters := s.getCounters(year)
+	records, err := db.GetQuestRecords(db.Anniv2026RecordsTable, s.dynamoClient)
+	if err != nil {
+		log.Printf("get recent games %v", err)
+		c.Status(500)
+		return err
+	}
+	recordHistory, err := db.GetQuestRecords(db.Anniv2026RecordHistory, s.dynamoClient)
+	sortedRecordHistory := s.sortRecordHistory(recordHistory)
+	sortedRecs := sortAnnivGames(records)
+	recordModel := struct {
+		Year            int
+		AnnivNumber     int
+		QuestNames      []string
+		QuestShortNames []string
+		TopLaps         []AnniversaryTimes
+		OverallCounter  QuestCounters
+		QuestCounters   map[string]QuestCounters
+		Records         map[string]map[string]model.FormattedGame
+		Classes         []psoclasses.PsoClass
+		SectionIds      []string
+		RecordHistory   map[string][]RecordHistoryPoint
+	}{
+		Year:        year,
+		AnnivNumber: 11,
+		QuestNames:  s.anniversaryNamesInOrder,
+		QuestShortNames: []string{"Forest",
+			"Caves",
+			"Mines",
+			"Ruins",
+			"Temple",
+			"Space",
+			"CCA",
+			"Seabed",
+			"Tower",
+			"Crater",
+			"Desert"},
+		TopLaps:        s.getTopLaps("a2026"),
+		OverallCounter: overallCounters,
+		QuestCounters:  questCounters,
+		Records:        sortedRecs,
+		Classes:        psoclasses.GetAll(),
+		SectionIds: []string{
+			"Viridia",
+			"Greenill",
+			"Skyly",
+			"Bluefull",
+			"Purplenum",
+			"Pinkal",
+			"Redria",
+			"Oran",
+			"Yellowboze",
+			"Whitill",
+		},
+		RecordHistory: sortedRecordHistory,
+	}
+
+	err = s.anniversary2022Template.ExecuteTemplate(c.Response().BodyWriter(), "index", recordModel)
+	c.Response().Header.Set("Content-Type", "text/html; charset=UTF-8")
+	return err
+}

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -118,6 +118,7 @@ func (s *Server) Run() {
 	s.app.Get("/anniv2022", s.Anniv2022RecordsPage)
 	s.app.Get("/anniv2023", s.Anniv2023RecordsPage)
 	s.app.Get("/anniv2025", s.Anniv2025RecordsPage)
+	s.app.Get("/anniv2026", s.Anniv2026RecordsPage)
 	//s.app.Get("/threejs", s.ThreejsPage)
 	//s.app.Get("/geometry", s.GetGeometry)
 	s.app.Get("/combo-calculator", s.ComboCalcMultiPage)

--- a/server/internal/server/write_game.go
+++ b/server/internal/server/write_game.go
@@ -125,7 +125,7 @@ func (s *Server) PostGame(c *fiber.Ctx) error {
 				log.Printf("failed to update leaderboard for game %v - %v", questRun.Id, err)
 			}
 		}
-		//s.updateAnniv2025Record(questRun, matchingGame)
+		s.updateAnniv2026Record(questRun, matchingGame)
 		s.recordsLock.Unlock()
 
 		playerPb, err := db.GetPlayerPB(questRun.QuestName, user.Id, numPlayers, questRun.PbCategory, s.dynamoClient)
@@ -160,38 +160,38 @@ func (s *Server) PostGame(c *fiber.Ctx) error {
 	return nil
 }
 
-func (s *Server) updateAnniv2025Record(questRun model.QuestRun, matchingGame *model.QuestRun) {
+func (s *Server) updateAnniv2026Record(questRun model.QuestRun, matchingGame *model.QuestRun) {
 	_, anniversaryQuest := s.anniversaryQuests[questRun.QuestName]
 	if questRun.PbCategory || !anniversaryQuest || questRun.Server != "ephinea" {
 		return
 	}
 	numPlayers := len(questRun.AllPlayers)
-	topRun, err := db.GetAnniv2025Record(questRun.QuestName, numPlayers, questRun.PbCategory, s.dynamoClient)
+	topRun, err := db.GetAnniv2026Record(questRun.QuestName, numPlayers, questRun.PbCategory, s.dynamoClient)
 	if err != nil {
 		log.Printf("failed to get top quest runs for gameId:%v - %v", questRun.Id, err)
 	} else if matchingGame != nil {
 		if topRun == nil {
 			log.Printf("Matching game but no topRun, almost definitely a bug")
 		} else if matchingGame.Id == topRun.Id {
-			if err := db.AddPovToRecord(db.Anniv2025RecordsTable, questRun, s.dynamoClient); err != nil {
+			if err := db.AddPovToRecord(db.Anniv2026RecordsTable, questRun, s.dynamoClient); err != nil {
 				log.Printf("failed to add pov to anniv record")
 			}
 		}
 	} else if isBetterRun(questRun, topRun) {
 		log.Printf("new record for %v %vp pb:%v - %v",
 			questRun.QuestName, numPlayers, questRun.PbCategory, questRun.Id)
-		if err = db.WriteAnniv2025Record(&questRun, s.dynamoClient); err != nil {
+		if err = db.WriteAnniv2026Record(&questRun, s.dynamoClient); err != nil {
 			log.Printf("failed to update anniv leaderboard for game %v - %v", questRun.Id, err)
 		}
 	}
 
-	pb, err := db.GetQuestSeriesPb("a2025", questRun.UserName, questRun.QuestName, s.dynamoClient)
+	pb, err := db.GetQuestSeriesPb("a2026", questRun.UserName, questRun.QuestName, s.dynamoClient)
 	if err != nil {
 		log.Printf("GetQuestSeriesPb %s", err)
 	}
 	questDuration, _ := time.ParseDuration(questRun.QuestDuration)
 	if pb == nil || questDuration < pb.Time {
-		err = db.WriteQuestSeriesPb("a2025", &questRun, s.dynamoClient)
+		err = db.WriteQuestSeriesPb("a2026", &questRun, s.dynamoClient)
 		if err != nil {
 			log.Printf("WriteQuestSeriesPb %s", err)
 		}

--- a/server/internal/templates/gamev3.gohtml
+++ b/server/internal/templates/gamev3.gohtml
@@ -135,7 +135,7 @@
                         <a class="nav-link" href="/records">Records</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/anniv2025">Anniversary</a>
+                        <a class="nav-link" href="/anniv2026">Anniversary</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="/info">Info</a>

--- a/server/internal/templates/gamev4.gohtml
+++ b/server/internal/templates/gamev4.gohtml
@@ -203,7 +203,7 @@
                         <a class="nav-link" href="/records">Records</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="/anniv2025">Anniversary</a>
+                        <a class="nav-link" href="/anniv2026">Anniversary</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="/info">Info</a>

--- a/server/internal/templates/navbar.gohtml
+++ b/server/internal/templates/navbar.gohtml
@@ -12,7 +12,7 @@
                 <a class="nav-link" href="/records">Records</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="/anniv2025">Anniversary</a>
+                <a class="nav-link" href="/anniv2026">Anniversary</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="/info">Info</a>


### PR DESCRIPTION
## Summary

- Adds the 2026 anniversary event page at `/anniv2026` (11th anniversary)
- New DynamoDB tables for 2026 records/history/stats, following the same per-year pattern as 2021/2022/2023/2025
- Re-enables the anniversary leaderboard write path (disabled after the 2025 event ended) and repoints it at the 2026 tables
- Nav "Anniversary" link now points at `/anniv2026`
- Historical anniversary pages (2021/2022/2023/2025) are untouched and remain browsable

## What changed

- `server/internal/db/db.go` — new `Anniv2026Stats`/`Anniv2026RecordHistory`/`Anniv2026RecordsTable` consts, `WriteAnniv2026Record` (renamed from `WriteAnniv2025Record`), new `GetAnniv2026Record`, `addAnniversaryCounter` now writes to `Anniv2026Stats`
- `server/internal/server/display_aniv2022.go` — `getCounters` routes year 2026 to the new stats table; anniversary countdown end-date bumped to 2026-09-12
- `server/internal/server/display_aniv2023.go` — new `Anniv2026RecordsPage` handler (`AnnivNumber: 11`), reuses the shared `anniv2022.gohtml` template like every prior year
- `server/internal/server/server.go` — registers `GET /anniv2026`
- `server/internal/server/write_game.go` — re-enables the (previously commented-out) anniversary record write call in `PostGame`, renames `updateAnniv2025Record` → `updateAnniv2026Record` and repoints all table/series-key references at 2026
- `server/internal/templates/navbar.gohtml`, `gamev3.gohtml`, `gamev4.gohtml` — Anniversary nav link now points at `/anniv2026`

## Test plan

- [x] `go build ./server/... ./pkg/...` passes
- [x] Started DynamoDB Local, created the 2026 anniversary tables, ran the dev server
- [x] `/anniv2026` renders 200 with correct `AnnivNumber: 11`, empty leaderboards (new tables, no data yet)
- [x] Navbar and in-game nav "Anniversary" link goes to `/anniv2026`
- [x] `/anniv2021`, `/anniv2022`, `/anniv2023`, `/anniv2025` behavior is unchanged by this PR (2021 renders as before; 2022/2023/2025 return 500 in this local dev environment due to their DynamoDB tables never having been provisioned locally — pre-existing, unrelated to this change, reproduces identically on `main` before this PR)