### PR TITLE
feat: add August Atrocity #1/#2 to 2026 anniversary page + backfill script

### DIFF
--- a/server/cmd/backfillanniv2026/main.go
+++ b/server/cmd/backfillanniv2026/main.go
@@ -1,0 +1,203 @@
+// Backfill script: replays anniversary record/PB/stats writes for games that were
+// submitted while anniv2026 record-writing was disabled (from the 2026 event's
+// opening, 2026-08-12 06:28 PDT, until the fix that re-enabled writes was deployed).
+// Regular leaderboard/game storage was never affected - only the anniv_*_2026 tables.
+//
+// Usage:
+//
+//	go run ./server/cmd/backfillanniv2026 -end=<deploy-timestamp-RFC3339> [-start=<RFC3339>] [-commit]
+//
+// -end is required. It MUST be set to the exact timestamp anniversary writes were
+// redeployed to production. The stats counters this script writes use DynamoDB ADD
+// (increment), which is NOT idempotent - any game the live server already recorded
+// after that deploy must NOT also be processed here, or its stats get double-counted.
+//
+// Without -commit the script only logs what it would do (dry run).
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/phelix-/psostats/v2/pkg/model"
+	"github.com/phelix-/psostats/v2/server/internal/db"
+	"github.com/phelix-/psostats/v2/server/internal/server"
+)
+
+// Mirrors the anniversaryQuests set in server/internal/server/server.go.
+var anniversaryQuests2026 = map[string]struct{}{
+	"Maximum Attack E: Forest": {},
+	"Maximum Attack E: Caves":  {},
+	"Maximum Attack E: Mines":  {},
+	"Maximum Attack E: Ruins":  {},
+	"Maximum Attack E: Temple": {},
+	"Maximum Attack E: Space":  {},
+	"Maximum Attack E: CCA":    {},
+	"Maximum Attack E: Seabed": {},
+	"Maximum Attack E: Tower":  {},
+	"Maximum Attack E: Crater": {},
+	"Maximum Attack E: Desert": {},
+	"August Atrocity #1":       {},
+	"August Atrocity #2":       {},
+}
+
+const gamesPerMonthLimit = 5000
+
+func main() {
+	startFlag := flag.String("start", "2026-08-12T06:28:00-07:00", "RFC3339 start of the backfill window (inclusive)")
+	endFlag := flag.String("end", "", "RFC3339 end of the backfill window (exclusive) - REQUIRED, set to the anniversary-writes deploy timestamp")
+	commit := flag.Bool("commit", false, "actually write to DynamoDB (default is dry-run)")
+	flag.Parse()
+
+	if *endFlag == "" {
+		log.Fatal("-end is required: set it to the timestamp anniversary record writes were redeployed, so this backfill doesn't overlap with games the live server already recorded")
+	}
+	start, err := time.Parse(time.RFC3339, *startFlag)
+	if err != nil {
+		log.Fatalf("invalid -start: %v", err)
+	}
+	end, err := time.Parse(time.RFC3339, *endFlag)
+	if err != nil {
+		log.Fatalf("invalid -end: %v", err)
+	}
+	if !end.After(start) {
+		log.Fatal("-end must be after -start")
+	}
+
+	var awsSession *session.Session
+	if _, set := os.LookupEnv("AWS_ACCESS_KEY_ID"); set {
+		awsSession = session.Must(session.NewSessionWithOptions(session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		}))
+	} else {
+		awsSession = session.Must(session.NewSession(&aws.Config{
+			Region:   aws.String("us-west-2"),
+			Endpoint: aws.String("http://localhost:8000"),
+		}))
+	}
+	dynamoClient := dynamodb.New(awsSession)
+
+	if *commit {
+		log.Printf("COMMIT mode: writes will be made to DynamoDB")
+	} else {
+		log.Printf("DRY RUN: pass -commit to actually write")
+	}
+	log.Printf("backfill window: [%s, %s)", start.Format(time.RFC3339), end.Format(time.RFC3339))
+
+	matched, written := 0, 0
+	for _, month := range monthsBetween(start, end) {
+		games, err := db.GetGamesForMonth(month, gamesPerMonthLimit, dynamoClient)
+		if err != nil {
+			log.Fatalf("get games for month %s: %v", month, err)
+		}
+		for _, game := range games {
+			if game.Timestamp.Before(start) || !game.Timestamp.Before(end) {
+				continue
+			}
+			if _, ok := anniversaryQuests2026[game.Quest]; !ok {
+				continue
+			}
+
+			gem := firstStatsGem(game)
+			if gem == -1 {
+				log.Printf("skip %s (%s): no player POV stats attached", game.Id, game.Quest)
+				continue
+			}
+			questRun, err := db.GetGame(game.Id, gem, dynamoClient)
+			if err != nil || questRun == nil {
+				log.Printf("skip %s: failed to load full game: %v", game.Id, err)
+				continue
+			}
+			if questRun.Server != "ephinea" || questRun.PbCategory || !server.IsLeaderboardCandidate(*questRun) {
+				continue
+			}
+
+			matched++
+			if *commit {
+				if err := backfillGame(*questRun, dynamoClient); err != nil {
+					log.Printf("error backfilling %s (%s): %v", questRun.Id, questRun.QuestName, err)
+					continue
+				}
+			}
+			written++
+			log.Printf("%s: %s %s %dp %s", questRun.QuestName, questRun.Id, questRun.UserName, len(questRun.AllPlayers), questRun.QuestDuration)
+		}
+	}
+
+	if *commit {
+		log.Printf("done: %d games matched, %d written", matched, written)
+	} else {
+		log.Printf("done: %d games matched, %d would be written (dry run, pass -commit to write)", matched, written)
+	}
+}
+
+// backfillGame replays the same anniv2026 writes that updateAnniv2026Record performs
+// for a live submission. Unlike the live path, it doesn't attach extra teammate POVs
+// to an existing record - each game is processed once for the submitting player's POV.
+// None of the anniversary quests are score-ranked (Endless-only), so this always
+// compares by duration.
+func backfillGame(questRun model.QuestRun, dynamoClient *dynamodb.DynamoDB) error {
+	numPlayers := len(questRun.AllPlayers)
+	questDuration, err := time.ParseDuration(questRun.QuestDuration)
+	if err != nil {
+		return err
+	}
+
+	topRun, err := db.GetAnniv2026Record(questRun.QuestName, numPlayers, questRun.PbCategory, dynamoClient)
+	if err != nil {
+		return err
+	}
+	if topRun == nil || questDuration < topRun.Time {
+		if err := db.WriteAnniv2026Record(&questRun, dynamoClient); err != nil {
+			return err
+		}
+	}
+
+	pb, err := db.GetQuestSeriesPb("a2026", questRun.UserName, questRun.QuestName, dynamoClient)
+	if err != nil {
+		return err
+	}
+	if pb == nil || questDuration < pb.Time {
+		if err := db.WriteQuestSeriesPb("a2026", &questRun, dynamoClient); err != nil {
+			return err
+		}
+	}
+
+	db.WriteAnniversaryStats(questRun, dynamoClient)
+	return nil
+}
+
+func firstStatsGem(game model.Game) int {
+	switch {
+	case game.P1HasStats:
+		return 0
+	case game.P2HasStats:
+		return 1
+	case game.P3HasStats:
+		return 2
+	case game.P4HasStats:
+		return 3
+	}
+	return -1
+}
+
+func monthsBetween(start, end time.Time) []string {
+	months := make([]string, 0, 2)
+	seen := make(map[string]bool)
+	for t := start; !t.After(end); t = t.AddDate(0, 1, 0) {
+		m := t.UTC().Format("01/2006")
+		if !seen[m] {
+			seen[m] = true
+			months = append(months, m)
+		}
+	}
+	if endMonth := end.UTC().Format("01/2006"); !seen[endMonth] {
+		months = append(months, endMonth)
+	}
+	return months
+}

--- a/server/internal/server/display_aniv2022.go
+++ b/server/internal/server/display_aniv2022.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *Server) Anniv2022RecordsPage(c *fiber.Ctx) error {
-	overallCounters, questCounters := s.getCounters(2022)
+	overallCounters, questCounters := s.getCounters(2022, s.anniversaryNamesInOrder)
 	records, err := db.GetQuestRecords(db.Anniv2021RecordsTable, s.dynamoClient)
 	if err != nil {
 		log.Printf("get recent games %v", err)
@@ -22,7 +22,7 @@ func (s *Server) Anniv2022RecordsPage(c *fiber.Ctx) error {
 		return err
 	}
 	recordHistory, err := db.GetQuestRecords(db.AnnivRecordHistory, s.dynamoClient)
-	sortedRecordHistory := s.sortRecordHistory(recordHistory)
+	sortedRecordHistory := s.sortRecordHistory(recordHistory, s.anniversaryNamesInOrder)
 	//for class, meseta := range overallCounters.ClassMesetaCharged {
 	//	fmt.Printf("%s - %02f\n", class, float64(meseta)/float64(overallCounters.ClassUse[class]))
 	//}
@@ -54,7 +54,7 @@ func (s *Server) Anniv2022RecordsPage(c *fiber.Ctx) error {
 			"Tower",
 			"Crater",
 			"Desert"},
-		TopLaps:        s.getTopLaps("a2022"),
+		TopLaps:        s.getTopLaps("a2022", s.anniversaryNamesInOrder),
 		OverallCounter: overallCounters,
 		QuestCounters:  questCounters,
 		Records:        sortedRecs,
@@ -94,12 +94,12 @@ func sortAnnivGames(games []model.Game) map[string]map[string]model.FormattedGam
 	return recordModel
 }
 
-func (s *Server) sortRecordHistory(games []model.Game) map[string][]RecordHistoryPoint {
+func (s *Server) sortRecordHistory(games []model.Game, questNames []string) map[string][]RecordHistoryPoint {
 	sort.Slice(games, func(i, j int) bool {
 		return games[i].Timestamp.Before(games[j].Timestamp)
 	})
 	gamesByQuest := make(map[string][]RecordHistoryPoint)
-	for _, quest := range s.anniversaryNamesInOrder {
+	for _, quest := range questNames {
 		gamesByQuest[quest] = make([]RecordHistoryPoint, 0)
 	}
 	for i, game := range games {
@@ -140,7 +140,7 @@ func (s *Server) sortRecordHistory(games []model.Game) map[string][]RecordHistor
 	return gamesByQuest
 }
 
-func (s *Server) getCounters(year int) (QuestCounters, map[string]QuestCounters) {
+func (s *Server) getCounters(year int, questNames []string) (QuestCounters, map[string]QuestCounters) {
 	questCounters := make(map[string]QuestCounters)
 
 	overallCounter := QuestCounters{
@@ -151,7 +151,7 @@ func (s *Server) getCounters(year int) (QuestCounters, map[string]QuestCounters)
 		Shifta:             make(map[int]int64),
 		RunsByDay:          make(map[time.Time]int64),
 	}
-	for _, questName := range s.anniversaryNamesInOrder {
+	for _, questName := range questNames {
 		questCounters[questName] = QuestCounters{
 			ClassMesetaCharged: make(map[string]int64),
 			ClassUse:           make(map[string]int64),
@@ -230,7 +230,7 @@ func (s *Server) getCounters(year int) (QuestCounters, map[string]QuestCounters)
 	return overallCounter, questCounters
 }
 
-func (s *Server) getTopLaps(questSeries string) []AnniversaryTimes {
+func (s *Server) getTopLaps(questSeries string, questNames []string) []AnniversaryTimes {
 	anniversaryTimes := make([]AnniversaryTimes, 0)
 	timesByPlayer := make(map[string]map[string]db.QuestSeriesPb)
 	if pbs, err := db.GetQuestSeriesPbs(questSeries, s.dynamoClient); err == nil {
@@ -244,13 +244,14 @@ func (s *Server) getTopLaps(questSeries string) []AnniversaryTimes {
 		}
 	}
 
+	questCount := len(questNames)
 	for user, times := range timesByPlayer {
-		durations := make([]time.Duration, 11)
-		formattedDurations := make([]string, 11)
-		gameIds := make([]string, 11)
+		durations := make([]time.Duration, questCount)
+		formattedDurations := make([]string, questCount)
+		gameIds := make([]string, questCount)
 		totalTime := time.Duration(0)
 		validTotalTime := true
-		for i, questName := range s.anniversaryNamesInOrder {
+		for i, questName := range questNames {
 			formattedTime := "N/A"
 			pb, found := times[fmt.Sprintf("%s", questName)]
 			if found {
@@ -276,7 +277,7 @@ func (s *Server) getTopLaps(questSeries string) []AnniversaryTimes {
 			Times:           formattedDurations,
 			individualTimes: durations,
 			GameIds:         gameIds,
-			Colors:          make([]string, 11),
+			Colors:          make([]string, questCount),
 		})
 	}
 
@@ -289,7 +290,7 @@ func (s *Server) getTopLaps(questSeries string) []AnniversaryTimes {
 	questBest := make(map[string]time.Duration)
 	questWorst := make(map[string]time.Duration)
 	for _, times := range anniversaryTimes {
-		for i, questName := range s.anniversaryNamesInOrder {
+		for i, questName := range questNames {
 			timeForQuest := times.individualTimes[i]
 			if bestTime, found := questBest[questName]; !found || timeForQuest < bestTime {
 				questBest[questName] = timeForQuest
@@ -300,7 +301,7 @@ func (s *Server) getTopLaps(questSeries string) []AnniversaryTimes {
 		}
 	}
 	for _, times := range anniversaryTimes {
-		for i, questName := range s.anniversaryNamesInOrder {
+		for i, questName := range questNames {
 			worstTimeForQuest := questWorst[questName]
 			bestTimeForQuest := questBest[questName]
 			questTime := times.individualTimes[i]

--- a/server/internal/server/display_aniv2023.go
+++ b/server/internal/server/display_aniv2023.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *Server) Anniv2023RecordsPage(c *fiber.Ctx) error {
-	overallCounters, questCounters := s.getCounters(2023)
+	overallCounters, questCounters := s.getCounters(2023, s.anniversaryNamesInOrder)
 	records, err := db.GetQuestRecords(db.Anniv2023RecordsTable, s.dynamoClient)
 	if err != nil {
 		log.Printf("get recent games %v", err)
@@ -17,7 +17,7 @@ func (s *Server) Anniv2023RecordsPage(c *fiber.Ctx) error {
 		return err
 	}
 	recordHistory, err := db.GetQuestRecords(db.Anniv2023RecordHistory, s.dynamoClient)
-	sortedRecordHistory := s.sortRecordHistory(recordHistory)
+	sortedRecordHistory := s.sortRecordHistory(recordHistory, s.anniversaryNamesInOrder)
 	sortedRecs := sortAnnivGames(records)
 	recordModel := struct {
 		Year            int
@@ -46,7 +46,7 @@ func (s *Server) Anniv2023RecordsPage(c *fiber.Ctx) error {
 			"Tower",
 			"Crater",
 			"Desert"},
-		TopLaps:        s.getTopLaps("a2023"),
+		TopLaps:        s.getTopLaps("a2023", s.anniversaryNamesInOrder),
 		OverallCounter: overallCounters,
 		QuestCounters:  questCounters,
 		Records:        sortedRecs,
@@ -73,7 +73,7 @@ func (s *Server) Anniv2023RecordsPage(c *fiber.Ctx) error {
 
 func (s *Server) Anniv2025RecordsPage(c *fiber.Ctx) error {
 	const year = 2025
-	overallCounters, questCounters := s.getCounters(year)
+	overallCounters, questCounters := s.getCounters(year, s.anniversaryNamesInOrder)
 	records, err := db.GetQuestRecords(db.Anniv2025RecordsTable, s.dynamoClient)
 	if err != nil {
 		log.Printf("get recent games %v", err)
@@ -81,7 +81,7 @@ func (s *Server) Anniv2025RecordsPage(c *fiber.Ctx) error {
 		return err
 	}
 	recordHistory, err := db.GetQuestRecords(db.Anniv2025RecordHistory, s.dynamoClient)
-	sortedRecordHistory := s.sortRecordHistory(recordHistory)
+	sortedRecordHistory := s.sortRecordHistory(recordHistory, s.anniversaryNamesInOrder)
 	sortedRecs := sortAnnivGames(records)
 	recordModel := struct {
 		Year            int
@@ -110,7 +110,7 @@ func (s *Server) Anniv2025RecordsPage(c *fiber.Ctx) error {
 			"Tower",
 			"Crater",
 			"Desert"},
-		TopLaps:        s.getTopLaps("a2025"),
+		TopLaps:        s.getTopLaps("a2025", s.anniversaryNamesInOrder),
 		OverallCounter: overallCounters,
 		QuestCounters:  questCounters,
 		Records:        sortedRecs,
@@ -137,7 +137,7 @@ func (s *Server) Anniv2025RecordsPage(c *fiber.Ctx) error {
 
 func (s *Server) Anniv2026RecordsPage(c *fiber.Ctx) error {
 	const year = 2026
-	overallCounters, questCounters := s.getCounters(year)
+	overallCounters, questCounters := s.getCounters(year, s.anniversaryNamesInOrder2026)
 	records, err := db.GetQuestRecords(db.Anniv2026RecordsTable, s.dynamoClient)
 	if err != nil {
 		log.Printf("get recent games %v", err)
@@ -145,7 +145,7 @@ func (s *Server) Anniv2026RecordsPage(c *fiber.Ctx) error {
 		return err
 	}
 	recordHistory, err := db.GetQuestRecords(db.Anniv2026RecordHistory, s.dynamoClient)
-	sortedRecordHistory := s.sortRecordHistory(recordHistory)
+	sortedRecordHistory := s.sortRecordHistory(recordHistory, s.anniversaryNamesInOrder2026)
 	sortedRecs := sortAnnivGames(records)
 	recordModel := struct {
 		Year            int
@@ -162,7 +162,7 @@ func (s *Server) Anniv2026RecordsPage(c *fiber.Ctx) error {
 	}{
 		Year:        year,
 		AnnivNumber: 11,
-		QuestNames:  s.anniversaryNamesInOrder,
+		QuestNames:  s.anniversaryNamesInOrder2026,
 		QuestShortNames: []string{"Forest",
 			"Caves",
 			"Mines",
@@ -173,8 +173,10 @@ func (s *Server) Anniv2026RecordsPage(c *fiber.Ctx) error {
 			"Seabed",
 			"Tower",
 			"Crater",
-			"Desert"},
-		TopLaps:        s.getTopLaps("a2026"),
+			"Desert",
+			"AA1",
+			"AA2"},
+		TopLaps:        s.getTopLaps("a2026", s.anniversaryNamesInOrder2026),
 		OverallCounter: overallCounters,
 		QuestCounters:  questCounters,
 		Records:        sortedRecs,

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -46,8 +46,9 @@ type Server struct {
 	anniversaryTemplate     *template.Template
 	anniversary2022Template *template.Template
 	comboCalcTemplate       *template.Template
-	anniversaryQuests       map[string]struct{}
-	anniversaryNamesInOrder []string
+	anniversaryQuests           map[string]struct{}
+	anniversaryNamesInOrder     []string
+	anniversaryNamesInOrder2026 []string
 }
 
 func New(dynamo *dynamodb.DynamoDB) *Server {
@@ -93,6 +94,21 @@ func New(dynamo *dynamodb.DynamoDB) *Server {
 			"Maximum Attack E: Tower",
 			"Maximum Attack E: Crater",
 			"Maximum Attack E: Desert",
+		},
+		anniversaryNamesInOrder2026: []string{
+			"Maximum Attack E: Forest",
+			"Maximum Attack E: Caves",
+			"Maximum Attack E: Mines",
+			"Maximum Attack E: Ruins",
+			"Maximum Attack E: Temple",
+			"Maximum Attack E: Space",
+			"Maximum Attack E: CCA",
+			"Maximum Attack E: Seabed",
+			"Maximum Attack E: Tower",
+			"Maximum Attack E: Crater",
+			"Maximum Attack E: Desert",
+			"August Atrocity #1",
+			"August Atrocity #2",
 		},
 	}
 }

--- a/server/internal/templates/anniv2022.gohtml
+++ b/server/internal/templates/anniv2022.gohtml
@@ -66,17 +66,7 @@
                 <table class="table table-dark">
                     <thead>
                     <tr><th scope="col">Overall</th><th scope="col">Player</th>
-                        <th scope="col">Forest</th>
-                        <th scope="col">Cave</th>
-                        <th scope="col">Mine</th>
-                        <th scope="col">Ruins</th>
-                        <th scope="col">Temple</th>
-                        <th scope="col">Space</th>
-                        <th scope="col">CCA</th>
-                        <th scope="col">Seabed</th>
-                        <th scope="col">Tower</th>
-                        <th scope="col">Crater</th>
-                        <th scope="col">Desert</th></tr>
+                        {{ range $root.QuestShortNames }}<th scope="col">{{ . }}</th>{{ end }}</tr>
                     </thead>
                     {{ range .TopLaps }}
                         <tr>
@@ -155,6 +145,8 @@
                 case "Maximum Attack E: Tower": return "#012a4a";
                 case "Maximum Attack E: Crater": return "#f8961e";
                 case "Maximum Attack E: Desert": return "#f94144";
+                case "August Atrocity #1": return "#9d4edd";
+                case "August Atrocity #2": return "#ff006e";
             }
         }
         const dailyQuestContext = document.getElementById("daily-quest-counts");


### PR DESCRIPTION
## Summary
- Adds August Atrocity #1 and #2 to the `/anniv2026` Overall Lap table, per-quest sections/charts, and Top Laps leaderboard. Scoped to 2026 only - older anniversary years (2022/2023/2025) keep their original 11-quest layout since AA1/AA2 never ran during those events.
- Adds `server/cmd/backfillanniv2026`, a one-off admin tool to replay anniversary record/PB/stats writes for games submitted while `anniv2026` record-writing was disabled (event opened 2026-08-12 06:28 PDT; writes were re-enabled in #68). Regular leaderboard/game storage was unaffected - only the `anniv_*_2026` tables need backfilling.

## Backfill usage (for @phelix-)
```
go run ./server/cmd/backfillanniv2026 -end=<exact deploy timestamp, RFC3339> [-commit]
```
- `-end` is required - set it to the exact timestamp this PR's fix was deployed to production. The stats counters use DynamoDB `ADD` (increment) and are not idempotent, so the window must stop exactly where live recording picked up to avoid double-counting.
- Defaults to dry-run (prints what it would write); pass `-commit` to actually write.
- `-start` defaults to 2026-08-12T06:28:00-07:00 (event open) if not overridden.

## Test plan
- [x] `go build ./server/...` passes
- [x] Verified locally against DynamoDB Local: seeded all 13 quests, confirmed `/anniv2026` renders AA1/AA2 in the table, per-quest charts, and Top Laps
- [x] Verified `/anniv2022`, `/anniv2023`, `/anniv2025` still render with only the original 11 quests (no regression)
- [ ] Phelix to dry-run the backfill script against production, review the log output, then re-run with `-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCQZHnv3dTmYMkg8fnGSy9